### PR TITLE
Fix: clear session token from sessionStorage on login failure

### DIFF
--- a/projects/angular-auth-lib/src/store/effects.ts
+++ b/projects/angular-auth-lib/src/store/effects.ts
@@ -135,7 +135,10 @@ export class AuthEffects {
         sessionStorage.setItem('token', loggedInUser.token.token);
         return this.authService.getUserInformation().pipe(
           map(({ user, usersList }) => new LogInSuccess({ user, usersList })),
-          catchError((error: HttpErrorResponse) => of(new LogInFailure(error)))
+          catchError((error: HttpErrorResponse) => {
+            sessionStorage.removeItem('token');
+            return of(new LogInFailure(error));
+          })
         );
       }),
       catchError((error: HttpErrorResponse) => of(new LogInFailure(error)))
@@ -164,9 +167,14 @@ export class AuthEffects {
   @Effect({ dispatch: false })
   LogInFailure$ = this.actions.pipe(
     ofType(AUTH_ACTIONS_TYPE.LOG_IN_FAILURE),
-    tap((error: LogInFailure) => this.toastService.error(
-      get(this.traductions || {}, 'messages.loginFailure', 'Wrong credentials. Please check again.')
-    ))
+    tap((error: LogInFailure) => {
+      if (isPlatformBrowser(this.platformId)) {
+        sessionStorage.removeItem('token');
+      }
+      this.toastService.error(
+        get(this.traductions || {}, 'messages.loginFailure', 'Wrong credentials. Please check again.')
+      );
+    })
   );
 
   @Effect()


### PR DESCRIPTION
When getUserInformation() fails after a successful token fetch, the valid JWT was left in sessionStorage while the UI showed a logged-out state. The TokenInterceptor reads directly from sessionStorage, so the orphaned token was silently attached to all subsequent requests.

Clear the token immediately in the inner catchError (primary fix) and in the LogInFailure$ effect (defense in depth) to ensure the stored credential's lifetime matches the authenticated session the user sees.

https://claude.ai/code/session_01QHNoW3cAQP4sz1NJCdpZ8K